### PR TITLE
refactor(kubernetes): use data workflow to stitch return data

### DIFF
--- a/kubernetes/workflows.yaml
+++ b/kubernetes/workflows.yaml
@@ -562,10 +562,18 @@ workflows:
                   parameters:
                     job: :path:wfdata.jobid
                     timeout: '{{ default "60" .wfdata.timeout }}'
-              - type: function
+              - type: pipe
+                data:
+                  kube_job_status: '{{ and (eq .labels.status "success") (eq (int .data.status.failed) 0) }}'
                 content:
-                  target:
-                    system: :path:wfdata.system
-                    function: getJobLog
-                  parameters:
-                    job: :path:wfdata.jobid
+                  - type: function
+                    content:
+                      target:
+                        system: :path:wfdata.system
+                        function: getJobLog
+                      parameters:
+                        job: :path:wfdata.jobid
+                  - type: data
+                    content:
+                      kube_job_status: :path:wfdata.kube_job_status
+                      log: :path:data.log


### PR DESCRIPTION
The data type workflow was added in v0.1.6, this the first case to use it.  This requires honeydipper/honeydipper#60