### PR TITLE
bug(pipe): strip off steps before sending to operators

### DIFF
--- a/workflow_helper.yaml
+++ b/workflow_helper.yaml
@@ -219,7 +219,11 @@ workflows:
         data:
           on_error: '{{ default "final" .wfdata.on_error }}'
         content:
-          - ':yaml:{{ index .wfdata "steps" 0 "work" | toJson }}'
+          - type: pipe
+            data:
+              "*steps": clear
+            content:
+              - ':yaml:{{ index .wfdata "steps" 0 "work" | toJson }}'
           - type: if
             condition: '{{ or (eq .wfdata.on_error "continue") (ne (coalesce .data.work_status .labels.status) "failure") }}'
             content:
@@ -236,6 +240,8 @@ workflows:
                 content:
                   - type: if
                     condition: '{{ and (eq .wfdata.on_error "final") (gt (len .wfdata.steps) 1) }}'
+                    data:
+                      "*steps": clear
                     content:
                       - ':yaml:{{ index (.wfdata.steps | last) "work" | toJson }}'
                   - type: data


### PR DESCRIPTION
By wrapping each step into a single step native `pipe` workflow, we get to mutate the workflow data and strip off the complicated logic in the `steps` before passing control to operator to make calls to drivers.  Without this, the operator service will attempt to interpolate data in `steps` which is not meant for consumption at that moment , causing interpolation errors.