### PR TITLE
Revert: break from repeat by setting times to 0

### DIFF
--- a/workflow_helper.yaml
+++ b/workflow_helper.yaml
@@ -45,7 +45,7 @@ workflows:
           - :path:wfdata.work
           - content: repeat
             data:
-              times: '{{ `{{ sub (int .wfdata.times) 1 }}` }}'
+              times: '{{ sub (int .wfdata.times) 1 }}'
               '*work': :path:wfdata.work
 
   # Workflow: Essentials.Workflows.foreach_parallel


### PR DESCRIPTION
This reverts honeydipper/honeydipper-config-essentials#25 56506e4.

The change doesn't work. It breaks the `repeat` workflow.  Should have tested it more.