### PR TITLE
feat: translate channel names to ids

### DIFF
--- a/slack/workflows.yaml
+++ b/slack/workflows.yaml
@@ -33,8 +33,11 @@ workflows:
             steps:
               - export:
                   known_command: "true"
+              - call_workflow: channel_translate
+                with:
+                  channel_names: $?ctx.invoked.allowed_channels
               - if_match:
-                  channel_name: $?ctx.invoked.allowed_channels
+                  channel_id: $?ctx.channel_ids
                   user_name: $?ctx.invoked.allowed_users
                 steps:
                   - call_workflow: $ctx.invoked.workflow
@@ -50,6 +53,8 @@ workflows:
                     notify: $?ctx.status_notify
                     message_type: error
                     message: The `{{ .ctx.command }}` command can only be used with whitelisted channels and/or users.
+            no_export:
+              - channel_ids
 
       # no matching command found
 

--- a/workflow_helper.yaml
+++ b/workflow_helper.yaml
@@ -10,7 +10,10 @@ workflows:
             - "failure"
         export:
           notify+: $?ctx.notify_on_error
-      - iterate_parallel: $?ctx.notify
+      - call_workflow: channel_translate
+        with:
+          channel_names: $?ctx.notify
+      - iterate_parallel: $?ctx.channel_ids
         iterate_as: channel_id
         switch: $ctx.channel_id
         cases:
@@ -20,6 +23,7 @@ workflows:
           call_function: '{{ .ctx.chat_system }}.say'
     no_export:
       - notify
+      - channel_ids
 
 
   workflow_announcement:
@@ -79,3 +83,11 @@ workflows:
   send_heartbeat:
     call_function: '{{ .ctx.alert_system }}.heartbeat'
     description: sending heartbeat to '{{ .ctx.alert_system }}'
+
+  channel_translate:
+    export:
+      channel_ids: |-
+        :yaml:---
+        {{- range .ctx.channel_names }}
+        - "{{ if or (empty $.ctx.channel_map) (hasKey $.ctx.channel_map . | not) }}{{ . }}{{ else }}{{ index $.ctx.channel_map . }}{{ end }}"
+        {{- end }}


### PR DESCRIPTION
Attempt 2

 * fixed a bug in daemon where trailing hook crash could result in crash looping, pushed to `DipperCL-rc3`
 * The actual change made the `channel_translate` working is a pair of quotes here https://github.com/honeydipper/honeydipper-config-essentials/blob/0c1cadded84e2deb3a4e124f2b76141468eb6ae6/workflow_helper.yaml#L92