### PR TITLE
feat: using new slack blocks

### DIFF
--- a/slack/systems.yaml
+++ b/slack/systems.yaml
@@ -55,11 +55,16 @@ systems:
             Content-Type: application/json
           method: POST
           content:
-            attachments:
-              - title: $?ctx.chat_title
+            attachments: |-
+              :yaml:---
+              {{ if empty .ctx.message }}
+              []
+              {{ else }}
+              - title: '{{ default "" .ctx.chat_title }}'
                 color: '{{ index .ctx.chat_colors .ctx.message_type }}'
-                text: $?ctx.message
-                blocks: $?ctx.blocks
+                text: {{ .ctx.message | toJson }}
+              {{ end }}
+            blocks: $?ctx.blocks
 
         description: >
           This function send a reply message to a slash command request. It is recommended to use
@@ -74,6 +79,8 @@ systems:
               description: a string that represents the type of the message, used for selecting colors
             - name: message
               description: the message to be sent
+            - name: blocks
+              description: construct the message using the slack :code:`layout blocks`, see slack document for detail
 
           notes:
             - See below for example
@@ -121,6 +128,8 @@ systems:
               description: >
                 The id of the channel the message is sent to. Use channel name here only when
                 sending to a public channel or to the home channel of the webhook.
+            - name: blocks
+              description: construct the message using the slack :code:`layout blocks`, see slack document for detail
 
           notes:
             - See below for example

--- a/slack/workflows.yaml
+++ b/slack/workflows.yaml
@@ -128,11 +128,15 @@ workflows:
 
     call_workflow: notify
     with:
-      message: |-
-        All supported commands
-        {{- range .ctx.slashcommands }}
-        `{{ .command }}` - {{ .usage }}
-        {{- end }}
+      blocks:
+        - type: section
+          text:
+            text: |-
+              *All supported commands*
+              {{- range .ctx.slashcommands }}
+              `{{ .command }}` - {{ .usage }}
+              {{- end }}
+            type: mrkdwn
 
   slashcommand/announcement:
     meta:


### PR DESCRIPTION
slack is recommending the new `layout blocks` format for constructing messages. The `layout blocks` doesn't support `attachments` `color` indicator bar, so slack recommends to use `blocks` within `attachments`. Unfortunately, it seems still buggy, `color` doesn't work any more if there are `blocks` in `attachments`. For now, we will continue use `attachments` for announcement and status messages but allow workflows and functions to use blocks through `ctx.blocks`. 