### PR TITLE
feat: allowing specify git access info through ctx

### DIFF
--- a/kubernetes/contexts.yaml
+++ b/kubernetes/contexts.yaml
@@ -51,10 +51,10 @@ contexts:
                 name: git-deploy-key
                 secret:
                   defaultMode: 384
-                  secretName: "{{ `{{ .sysData.git_key_secret }}` }}"
+                  secretName: "{{ default `{{ .sysData.git_key_secret }}` .ctx.git_key_secret }}"
           env:
             - name: REPO
-              value: '{{ `{{ .sysData.git_url }}` }}'
+              value: '{{ default `{{ .sysData.git_url }}` .ctx.git_url }}'
             - name: BRANCH
               value: '{{ default "" .ctx.git_ref }}'
 


### PR DESCRIPTION
When running `git-clone` in `run_kubernetes`, we can specify the git access in `sysData`. But it is not flexible enough.  Using `ctx` data is a lot of easier. This is backwards compatible.