### PR TITLE
feat: retrying get kube job status

### DIFF
--- a/kubernetes/workflows.yaml
+++ b/kubernetes/workflows.yaml
@@ -216,4 +216,6 @@ workflows:
       - on_failure: continue
         steps:
           - call_function: '{{ .ctx.system }}.waitForJob'
+            with:
+              retry: 2
           - call_function: '{{ .ctx.system }}.getJobLog'


### PR DESCRIPTION
This is helpful when running into transient errors.