### PR TITLE
fix: branch name should be the base name of the ref

### DIFF
--- a/kubernetes/contexts.yaml
+++ b/kubernetes/contexts.yaml
@@ -118,7 +118,7 @@ contexts:
                   secretName: "{{ default `{{ .sysData.git_key_secret }}` .ctx.git_key_secret }}"
           env:
             REPO: '{{ default `{{ .sysData.git_url }}` .ctx.git_url }}'
-            BRANCH: '{{ default "" .ctx.git_ref }}'
+            BRANCH: '{{ default "" .ctx.git_ref | base }}'
             DIR: repo
 
         git-clone-opaque-key:
@@ -130,7 +130,7 @@ contexts:
             ssh-agent sh -c "ssh-add /honeydipper/.ssh/id_rsa 2>/dev/null; git clone --single-branch ${BRANCH:+--branch} $BRANCH $REPO $DIR"
           env:
             REPO: '{{ default `{{ .sysData.git_url }}` .ctx.git_url }}'
-            BRANCH: '{{ default "" .ctx.git_ref }}'
+            BRANCH: '{{ default "" .ctx.git_ref | base }}'
             DIR: repo
 
         git-push:


### PR DESCRIPTION
The `git_ref` context variable contains the ref name as `refs/heads/<name>`, but the clone command running in k8s job only needs the name part.  So, use `base` function from sprig http://masterminds.github.io/sprig/paths.html to strip the path.