### PR TITLE
feat(k8s): delete jobs upon successful completion

### DIFF
--- a/kubernetes/system.yaml
+++ b/kubernetes/system.yaml
@@ -80,6 +80,40 @@ systems:
                           with:
                             deployment: app=bar
 
+      deleteJob:
+        driver: kubernetes
+        rawAction: deleteJob
+        parameters:
+          source: $sysData.source
+          namespace: $?sysData.namespace
+          job: $ctx.jobid
+
+        description: >
+          This function deletes a kubernetes job specified by the job name in :code:`.ctx.jobid`.
+          It leverages the pre-configured system data to access the kubernetes cluster.
+
+        meta:
+          inputs:
+            - name: jobid
+              description: The name of the kubernetes job
+
+          notes:
+            - See below for example
+            - example: |
+                ---
+                workflows:
+                  run_myjob:
+                    - call_function: myk8scluster.createJob
+                      ...
+                      # this function exports .ctx.jobid
+                    - call_function: myk8scluster.waitForJob
+                      ...
+                    - call_function: myk8scluster.deleteJob
+            - >
+              This function is not usually used directly by users. It is added to the :ref:`run_kubernetes` workflow so
+              that, upon successful completion, the job will be deleted. In rare cases, you can use the wrapper workflow
+              :ref:`cleanup_k8s_job` to delete a job.
+
       createJob:
         driver: kubernetes
         rawAction: createJob

--- a/kubernetes/workflows.yaml
+++ b/kubernetes/workflows.yaml
@@ -166,7 +166,12 @@ workflows:
         - name: cleanupAfter
           description: >
             Used for setting the :code:`TTLSecondsAfterFinished` for the k8s job, requires 1.13+
-            and the feature to be enabled for the cluster.
+            and the alpha features to be enabled for the cluster. The feature is still in alpha as of k8s 1.18.
+
+        - name: no_cleanup_k8s_job
+          description: >
+            By default, the job will be deleted upon successful completion. Setting this context variable to a truthy value will
+            ensure that the successful job is kept in the cluster.
 
       exports:
         - name: log
@@ -219,3 +224,25 @@ workflows:
             with:
               retry: 2
           - call_function: '{{ .ctx.system }}.getJobLog'
+        with:
+          hooks:
+            on_success: cleanup_kube_job
+
+  cleanup_kube_job:
+    description: delete a kubernetes job
+    meta:
+      inputs:
+        - name: system
+          description: The k8s system to use to delete the job
+        - name: no_cleanup_k8s_job
+          description: If set to truthy value, will skip deleting the job
+      notes:
+        - >
+          This workflow is intended to be invoked by :ref:`run_kuberentes` workflow as a hook upon
+          successful completion.
+
+    unless:
+      - '{{ .ctx.no_cleanup_k8s_job }}'
+    call_function: '{{ .ctx.system }}.deleteJob'
+    with:
+      retry: 2


### PR DESCRIPTION
Since the `TTLSecondsAfterFinish` is stuck in alpha as of kubernetes 1.18, we need a way to clean up the finished jobs. Since `honeydipper` `1.4.0`, the `deleteJob` feature is added to the driver.  By adding this, the `run_kubernetes` workflow itself will take care of the clean up.