### PR TITLE
feat(notify): enable displaying links in the workflow status

### DIFF
--- a/gcloud/init.yaml
+++ b/gcloud/init.yaml
@@ -3,3 +3,4 @@ includes:
   - drivers.yaml
   - contexts.yaml
   - workflows.yaml
+  - systems.yaml

--- a/gcloud/systems.yaml
+++ b/gcloud/systems.yaml
@@ -1,0 +1,20 @@
+---
+systems:
+  kubernetes:
+    data:
+      types:
+        gcloud-gke:
+          joblinks:
+            job:
+              url: "https://console.cloud.google.com/kubernetes/job/{{ .params.source.location }}/{{ .params.source.cluster }}/default/{{ .data.metadata.name }}?project={{ .params.source.project }}&tab=details&duration=PT1H&pod_summary_list_tablesize=20&service_list_datatablesize=20"
+              text: See job {{ .data.metadata.name }} in console
+            log:
+              url: "https://console.cloud.google.com/logs/viewer?project={{ .params.source.project }}&advancedFilter=resource.type%3D%22k8s_container%22%0Aresource.labels.project_id%3D%22{{ .params.source.project }}%22%0Aresource.labels.location%3D%22{{ .params.source.location }}%22%0Aresource.labels.cluster_name%3D%22{{ .params.source.cluster }}%22%0Aresource.labels.namespace_name%3D%22{{ .params.namespace }}%22%0Alabels.%22k8s-pod%2Fjob-name%22%3D%22{{ .data.metadata.name }}%22"
+              text: View logs in Stackdriver
+
+  dataflow:
+    data:
+      joblinks:
+        job:
+          url: "https://console.cloud.google.com/dataflow/jobs/{{ .sysData.locations.backup }}/{{ .data.job.id }}?project={{ .sysData.project }}"
+          text: See job {{ .data.job.name }} in console

--- a/github.yaml
+++ b/github.yaml
@@ -43,7 +43,7 @@ systems:
         driver: web
         rawAction: request
         parameters:
-          URL: https://api.github.com/{{ .ctx.resource_path }}
+          URL: https://api.github.com/{{ coalesce .params.resource_path .ctx.resource_path }}
           header:
             Authorization: token {{ coalesce .ctx.github_oauth_token .sysData.oauth_token }}
             Accept: application/vnd.github.v3+json
@@ -63,7 +63,7 @@ systems:
           system: github
           function: api
         parameters:
-          URL: 'https://api.github.com/repos/{{ .ctx.git_repo }}/pulls'
+          resource_path: 'repos/{{ .ctx.git_repo }}/pulls'
           method: POST
           content: $ctx.PR_content
         export:
@@ -109,7 +109,7 @@ systems:
           system: github
           function: api
         parameters:
-          URL: 'https://api.github.com/orgs/{{ .ctx.org }}/repos'
+          resource_path: 'orgs/{{ .ctx.org }}/repos'
           method: POST
           content:
             name: $ctx.name
@@ -153,7 +153,7 @@ systems:
           system: github
           function: api
         parameters:
-          URL: 'https://api.github.com/user/installations/{{ .ctx.installationid }}/repositories/{{ .ctx.repoid }}'
+          resource_path: 'user/installations/{{ .ctx.installationid }}/repositories/{{ .ctx.repoid }}'
           method: PUT
           header:
             Authorization: token {{ .sysData.oauth_token }}
@@ -194,7 +194,7 @@ systems:
           system: github
           function: api
         parameters:
-          URL: 'https://api.github.com/repos/{{ .ctx.git_repo }}/statuses/{{ .ctx.git_commit }}'
+          resource_path: 'repos/{{ .ctx.git_repo }}/statuses/{{ .ctx.git_commit }}'
           method: POST
           content: '{{ set .ctx.status "context" (coalesce .ctx.context .sysData.context "Honeydipper") | toJson }}'
 
@@ -242,7 +242,7 @@ systems:
           system: github
           function: api
         parameters:
-          URL: 'https://api.github.com/repos/{{ .ctx.git_repo }}/issues/{{ .ctx.git_issue }}/comments'
+          resource_path: 'repos/{{ .ctx.git_repo }}/issues/{{ .ctx.git_issue }}/comments'
           method: POST
           content: '{{ dict "body" .ctx.message | toJson }}'
 
@@ -282,7 +282,7 @@ systems:
           system: github
           function: api
         parameters:
-          URL: 'https://api.github.com/repos/{{ .ctx.git_repo }}/contents/{{ .ctx.path }}{{ if .ctx.git_ref }}?ref={{ .ctx.git_ref }}{{ end }}'
+          resource_path: 'repos/{{ .ctx.git_repo }}/contents/{{ .ctx.path }}{{ if .ctx.git_ref }}?ref={{ .ctx.git_ref }}{{ end }}'
           method: GET
         export:
           file_content: '{{ b64dec .data.json.content }}'

--- a/kubernetes/system.yaml
+++ b/kubernetes/system.yaml
@@ -87,6 +87,10 @@ systems:
           source: $sysData.source
           namespace: $?sysData.namespace
           job: $ctx.jobid
+        export:
+          links:
+            job:
+              text: 'deleted'
 
         description: >
           This function deletes a kubernetes job specified by the job name in :code:`.ctx.jobid`.
@@ -123,6 +127,7 @@ systems:
           job: $ctx.job
         export:
           jobid: $data.metadata.name
+          links: $?sysData.types.{{ .sysData.source.type }}.joblinks
 
         description: >
           This function creates a k8s run-to-completion job with given job spec data structure. It is a wrapper

--- a/slack/systems.yaml
+++ b/slack/systems.yaml
@@ -46,11 +46,10 @@ systems:
       slash_path: "/slack/slashcommand"
 
     functions:
-      reply:
+      send_message:
         driver: web
         rawAction: request
         parameters:
-          URL: $ctx.response_url
           header:
             Content-Type: application/json
           method: POST
@@ -66,6 +65,13 @@ systems:
               {{ end }}
             response_type: '{{ default "ephemeral" .ctx.response_type }}'
             blocks: $?ctx.blocks
+
+      reply:
+        target:
+          system: slack
+          function: send_message
+        parameters:
+          URL: $ctx.response_url
 
         description: >
           This function send a reply message to a slash command request. It is recommended to use
@@ -106,7 +112,7 @@ systems:
       say:
         target:
           system: slack
-          function: reply
+          function: send_message
         parameters:
           URL: $sysData.url
           content:

--- a/workflow_helper.yaml
+++ b/workflow_helper.yaml
@@ -120,8 +120,15 @@ workflows:
     with:
       message_type: $labels.status
       message: $?ctx.status_message
-      message-: >-
+      message-: |-
         `{{ coalesce .ctx._meta_desc .ctx._meta_name "Unnamed workflow" }}` is completed with status `{{ .labels.status }}`
+        {{- if not (empty .ctx.links) }}
+        {{ range $k, $v := .ctx.links }}
+        {{- if ne $v.text "deleted" }}
+        * <{{ $v.url }}|{{ coalesce $v.text $k }}>
+        {{- end }}
+        {{- end }}
+        {{- end }}
         {{ if ne .labels.status "success" }}
         {{   printf "\nwhile performing `%s`\n" .labels.performing }}
         ```{{   if (gt (len .labels.reason) 512) }}


### PR DESCRIPTION
This allows the workflow status message to display links, if the workflow exports a `links` context variable.

~~This PR goes hand in hand with honeydipper/honeydipper#249 . But, it can be shipped separately as it won't break anything. If `links` context variable is not defined, the behavior won't change.~~

The implementation of the links are done on the `system` level, and this is enabled by PR honeydipper/honeydipper#252 in version `1.5.0`.