### PR TITLE
fix(gcloud): k8s job log link with default namespace

### DIFF
--- a/gcloud/systems.yaml
+++ b/gcloud/systems.yaml
@@ -9,7 +9,7 @@ systems:
               url: "https://console.cloud.google.com/kubernetes/job/{{ .params.source.location }}/{{ .params.source.cluster }}/default/{{ .data.metadata.name }}?project={{ .params.source.project }}&tab=details&duration=PT1H&pod_summary_list_tablesize=20&service_list_datatablesize=20"
               text: See job {{ .data.metadata.name }} in console
             log:
-              url: "https://console.cloud.google.com/logs/viewer?project={{ .params.source.project }}&advancedFilter=resource.type%3D%22k8s_container%22%0Aresource.labels.project_id%3D%22{{ .params.source.project }}%22%0Aresource.labels.location%3D%22{{ .params.source.location }}%22%0Aresource.labels.cluster_name%3D%22{{ .params.source.cluster }}%22%0Aresource.labels.namespace_name%3D%22{{ .params.namespace }}%22%0Alabels.%22k8s-pod%2Fjob-name%22%3D%22{{ .data.metadata.name }}%22"
+              url: "https://console.cloud.google.com/logs/viewer?project={{ .params.source.project }}&advancedFilter=resource.type%3D%22k8s_container%22%0Aresource.labels.project_id%3D%22{{ .params.source.project }}%22%0Aresource.labels.location%3D%22{{ .params.source.location }}%22%0Aresource.labels.cluster_name%3D%22{{ .params.source.cluster }}%22%0Aresource.labels.namespace_name%3D%22{{ default `default` .params.namespace }}%22%0Alabels.%22k8s-pod%2Fjob-name%22%3D%22{{ .data.metadata.name }}%22"
               text: View logs in Stackdriver
 
   dataflow:


### PR DESCRIPTION
The link will break if namespace is not specified.