### PR TITLE
fix(gcloud): distinguish different job links

### DIFF
--- a/gcloud/systems.yaml
+++ b/gcloud/systems.yaml
@@ -5,16 +5,16 @@ systems:
       types:
         gcloud-gke:
           joblinks:
-            job:
+            k8s_job:
               url: "https://console.cloud.google.com/kubernetes/job/{{ .params.source.location }}/{{ .params.source.cluster }}/default/{{ .data.metadata.name }}?project={{ .params.source.project }}&tab=details&duration=PT1H&pod_summary_list_tablesize=20&service_list_datatablesize=20"
-              text: See job {{ .data.metadata.name }} in console
+              text: See Kubernetes job {{ .data.metadata.name }} in console
             log:
               url: "https://console.cloud.google.com/logs/viewer?project={{ .params.source.project }}&advancedFilter=resource.type%3D%22k8s_container%22%0Aresource.labels.project_id%3D%22{{ .params.source.project }}%22%0Aresource.labels.location%3D%22{{ .params.source.location }}%22%0Aresource.labels.cluster_name%3D%22{{ .params.source.cluster }}%22%0Aresource.labels.namespace_name%3D%22{{ default `default` .params.namespace }}%22%0Alabels.%22k8s-pod%2Fjob-name%22%3D%22{{ .data.metadata.name }}%22"
-              text: View logs in Stackdriver
+              text: View Kubernetes job logs in Stackdriver
 
   dataflow:
     data:
       joblinks:
-        job:
+        dataflow_job:
           url: "https://console.cloud.google.com/dataflow/jobs/{{ .sysData.locations.backup }}/{{ .data.job.id }}?project={{ .sysData.project }}"
-          text: See job {{ .data.job.name }} in console
+          text: See Dataflow job {{ .data.job.name }} in console

--- a/kubernetes/system.yaml
+++ b/kubernetes/system.yaml
@@ -89,7 +89,7 @@ systems:
           job: $ctx.jobid
         export:
           links:
-            job:
+            k8s_job:
               text: 'deleted'
 
         description: >


### PR DESCRIPTION
We may have different jobs in the workflow, and the links may overlap.