### PR TITLE
feat(k8s): adding labels to job

### DIFF
--- a/kubernetes/resources/honeydipper-job.yaml.tmpl
+++ b/kubernetes/resources/honeydipper-job.yaml.tmpl
@@ -1,5 +1,6 @@
 :yaml:---
 {{- $finalStepNum := sub (len .ctx.steps) 1 }}
+{{- $uniqueID := (empty $.ctx.unique_identifier | ternary (uuidv4) $.ctx.unique_identifier) }}
 {{- define "volumeMounts" }}
           {{- range . }}
             - mountPath: {{ .mountPath }}
@@ -89,8 +90,15 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   generateName: "honeydipper-job-"
+  labels:
+    creator: honeydipper
+    honeydipper-unique-identifier: "{{ $uniqueID }}"
 spec:
   template:
+    metadata:
+      labels:
+        creator: honeydipper
+        honeydipper-unique-identifier: "{{ $uniqueID }}"
     spec:
       {{- with (initial .ctx.steps) }}
       initContainers:


### PR DESCRIPTION
 * a generic identifying label for getting all honeydipper created
 * unique identifier for each job to avoid creating duplicates

With the identifying label, it is easier to maintain them in batch. For example:
```
kubectl delete pods -l creator=honeydipper --field-selector status.phase!=Running,status.phase!=Pending,status.phase!=Unknown
```

To identify one
```
kubectl get jobs -l honeydipper-unique-identifier=restoring-users-staging
```