### PR TITLE
feat(slack): allow disable the slashcommand status through contexts

### DIFF
--- a/slack/contexts.yaml
+++ b/slack/contexts.yaml
@@ -20,5 +20,10 @@ contexts:
           usage: reload honeydipper config
           workflow: reload
 
+    slashcommand/execute:
+      hooks:
+        on_exit:
+          - slashcommand/status
+
     reload:
       force: '{{ splitList " " .ctx.parameters | has "force" }}'

--- a/slack/workflows.yaml
+++ b/slack/workflows.yaml
@@ -94,14 +94,7 @@ workflows:
               - if_match:
                   channel_id: $?ctx.channel_ids
                   user_name: $?ctx.invoked.allowed_users
-                steps:
-                  - call_workflow: $ctx.invoked.workflow
-                    contexts: $?ctx.invoked.contexts
-                    with:
-                      slashcommands: ':yaml:{{ empty .ctx.invoked.keep_commands | ternary "*removed*" .ctx.slashcommands | toJson }}'
-                      hooks:
-                        on_exit:
-                          - slashcommand/status
+                call_workflow: slashcommand/execute
                 else:
                   call_workflow: notify
                   with:
@@ -119,6 +112,12 @@ workflows:
           notify: $?ctx.status_notify
           message_type: error
           message: Unknown command `{{ .ctx.command }}`
+
+  slashcommand/execute:
+    call_workflow: $ctx.invoked.workflow
+    contexts: $?ctx.invoked.contexts
+    with:
+      slashcommands: ':yaml:{{ empty .ctx.invoked.keep_commands | ternary "*removed*" .ctx.slashcommands | toJson }}'
 
   slashcommand/help:
     meta:


### PR DESCRIPTION
Override the `hooks` for the `slashcommand/execute` workflow will change when/how the
status message is sent.