### PR TITLE
fix(kubernetes): make waitForJob retry variable

### DIFF
--- a/kubernetes/workflows.yaml
+++ b/kubernetes/workflows.yaml
@@ -222,7 +222,7 @@ workflows:
         steps:
           - call_function: '{{ .ctx.system }}.waitForJob'
             with:
-              retry: 2
+              retry: $ctx.k8s_job_wait_retry,"2"
           - call_function: '{{ .ctx.system }}.getJobLog'
         with:
           hooks:


### PR DESCRIPTION
 * longer jobs, such as db scrubbing taking days, need more retry during watching period.