### PR TITLE
fix(slack): the slash command status message should show actual wf name

### DIFF
--- a/slack/workflows.yaml
+++ b/slack/workflows.yaml
@@ -118,6 +118,8 @@ workflows:
     contexts: $?ctx.invoked.contexts
     with:
       slashcommands: ':yaml:{{ empty .ctx.invoked.keep_commands | ternary "*removed*" .ctx.slashcommands | toJson }}'
+    # override the message to show actual workflow name in slack status messages
+    description: $ctx.invoked.workflow
 
   slashcommand/help:
     meta:


### PR DESCRIPTION

When moving the execution to the `slashcommand/execute` workflow, the status message
shows the new workflow name `slashcommand/execute` instead of the actual
workflow for the command. We can override this by setting the `description`
with the name of the actual workflow.