### PR TITLE
fix(jira): use current API stable version 2

### DIFF
--- a/jira.yaml
+++ b/jira.yaml
@@ -51,7 +51,7 @@ systems:
         rawAction: request
         parameters:
           method: POST
-          URL: https://{{ .sysData.jira_domain }}.{{ .sysData.jira_domain_base }}/rest/api/3/issue/
+          URL: https://{{ .sysData.jira_domain }}.{{ .sysData.jira_domain_base }}/rest/api/2/issue/
           header:
             Authorization: Basic {{ .sysData.jira_credentials }}
             Accept: application/json
@@ -107,7 +107,7 @@ systems:
         rawAction: request
         parameters:
           method: POST
-          URL: https://{{ .sysData.jira_domain }}.{{ .sysData.jira_domain_base }}/rest/api/3/issue/{{ .ctx.jira_ticket }}/comment
+          URL: https://{{ .sysData.jira_domain }}.{{ .sysData.jira_domain_base }}/rest/api/2/issue/{{ .ctx.jira_ticket }}/comment
           header:
             Authorization: Basic {{ .sysData.jira_credentials }}
             Accept: application/json


### PR DESCRIPTION
Turns out that the current stable version for the atlassian API is 2,
and the version 3 [Atlassian Document Format](https://developer.atlassian.com/cloud/jira/platform/apis/document/structure/)
is really hard to use. I don't like the version 3. I think they should
maintain compatibility to version 2 document formatting approach in the
future.