### PR TITLE
feat(k8s): allow k8s job with variable backoffLimit

### DIFF
--- a/kubernetes/resources/honeydipper-job.yaml.tmpl
+++ b/kubernetes/resources/honeydipper-job.yaml.tmpl
@@ -143,7 +143,7 @@ spec:
       tolerations:
         {{ . | toJson }}
       {{- end }}
-  backoffLimit: 1
+  backoffLimit: {{ default 0 .ctx.k8s_job_backoffLimit }}
   {{- with .ctx.timeout }}
   activeDeadlineSeconds: {{ . }}
   {{- end }}

--- a/kubernetes/workflows.yaml
+++ b/kubernetes/workflows.yaml
@@ -173,6 +173,11 @@ workflows:
             By default, the job will be deleted upon successful completion. Setting this context variable to a truthy value will
             ensure that the successful job is kept in the cluster.
 
+        - name: k8s_job_backoffLimit
+          description: >
+            By default, the job will not retry if the pod fails (:code:`backoffLimit` set to 0), you can use this
+            to override the setting for the job.
+
       exports:
         - name: log
           description: The logs of the job organized in map by container and by pod


### PR DESCRIPTION
Previously, the `backoffLimit` was hardcoded as 1, meaning the job will
retry the work once if the pod fails. This change makes it a variable so
we can adjust it as needed, and set the default to 0 for not retrying.