### PR TITLE
fix(github): converting repoid number to string

### DIFF
--- a/github.yaml
+++ b/github.yaml
@@ -112,7 +112,7 @@ systems:
           method: GET
         export:
           repo: $data.json
-          repoid: $data.json.id
+          repoid: '{{ .data.json.id | int }}'
 
         description: >
           This function will query the detailed information about the repo.


### PR DESCRIPTION
It is easier to use a string as `repoid`. Or, In some places, the
template will convert that into a scientific notation representation.