### PR TITLE
fix(circleci): typo in docs

### DIFF
--- a/circleci.yaml
+++ b/circleci.yaml
@@ -9,7 +9,7 @@ systems:
       configurations:
         - name: circle_token
           description: The token for making API calls to `circleci`.
-        - nme: url
+        - name: url
           description: The base url of the API calls, defaults to :code:`https://circleci.com/api/v2`
 
     data:


### PR DESCRIPTION
This only affects the generated documents on readthedoc.io.