### PR TITLE
fix(kubernetes): tf script type imagePullPolicy Always

### DIFF
--- a/kubernetes/contexts.yaml
+++ b/kubernetes/contexts.yaml
@@ -28,6 +28,7 @@ contexts:
           shell_entry: [ "/bin/sh", "-c" ]
         tf:
           image: hashicorp/terraform:light
+          imagePullPolicy: Always
           command_prefix: []
           shell_entry: [ "/bin/sh", "-c" ]
         helm:

--- a/kubernetes/resources/honeydipper-job.yaml.tmpl
+++ b/kubernetes/resources/honeydipper-job.yaml.tmpl
@@ -37,6 +37,9 @@
         {{- $processor := index $script_types (default "bash" .type) }}
         - name: step-{{ default $index .name }}
           image: {{ $processor.image }}
+          {{- with $processor.imagePullPolicy }}
+          imagePullPolicy: {{ . }}
+          {{- end }}
           workingDir: '{{ default "/honeydipper" .workingDir }}'
           env:
             {{- if (and (empty $env) (empty .env)) }}


### PR DESCRIPTION
The `light` tag doesnt get updated once the image is downloaded
causing the inconsistency between nodes in kubernetes clusters.

This change allows customizing the `imagePullPolicy` for each
script type. And, we can use `Always` pull for tf script.