### PR TITLE
fix(slack): slashcommand send status use channel id

### DIFF
--- a/slack/workflows.yaml
+++ b/slack/workflows.yaml
@@ -228,7 +228,7 @@ workflows:
     call_workflow: workflow_status
     with:
       notify+:
-        - $ctx.channel_fullname
+        - $ctx.channel_id
 
   slashcommand/prepare_notification_list:
     meta:


### PR DESCRIPTION
Right now, slashcommand status messages in private channels are missing
because we use `channel_fullname` to send feedback. But, the
`channel_fullname` will be `#privategroup` for all the private channels.
Switching to `channel_id` should fix this.