### PR TITLE
fix(slack): slashcommand status message dedupe

### DIFF
--- a/slack/workflows.yaml
+++ b/slack/workflows.yaml
@@ -225,10 +225,20 @@ workflows:
         - >
           This workflow sends a status message to the channels listed in :code:`slash_notify`.  Used internally.
 
-    call_workflow: workflow_status
-    with:
-      notify+:
-        - $ctx.channel_id
+    if_match:
+      channel_name:
+        - privategroup
+        - directmessage
+    steps:
+      - call_workflow: workflow_status
+        with:
+          notify+:
+            - $ctx.channel_id
+    else:
+      call_workflow: workflow_status
+      with:
+        notify+:
+          - $ctx.channel_fullname
 
   slashcommand/prepare_notification_list:
     meta:

--- a/workflow_helper.yaml
+++ b/workflow_helper.yaml
@@ -310,9 +310,15 @@ workflows:
                     #     - U78JS2F
                     #     - '#public_channel1' # remain unchanged if missing from the map
 
-    export:
-      channel_ids: |-
+    with:
+      translated: |-
         :yaml:---
         {{- range default (list) .ctx.channel_names | uniq }}
         - "{{ if or (empty $.ctx.channel_map) (hasKey $.ctx.channel_map . | not) }}{{ . }}{{ else }}{{ index $.ctx.channel_map . }}{{ end }}"
+        {{- end }}
+    export:
+      channel_ids: |-
+        :yaml:---
+        {{- range default (list) .ctx.translated | uniq }}
+        - "{{ . }}"
         {{- end }}


### PR DESCRIPTION
If the slash command is from private channel or direct message, we
should use the `channel_id` to send reply but if it is a public channel,
we should use the `channel_fullname` so the list of channels can be
properly deduped.

Also updated `channel_translate` with one more `uniq` function on the
output to ensure that the final list of `channel_ids` are all unique.