### PR TITLE
feat(gcloud): add gcloud-secret driver and docs

### DIFF
--- a/gcloud/drivers.yaml
+++ b/gcloud/drivers.yaml
@@ -3,6 +3,8 @@ drivers:
   daemon:
     features:
       global:
+        - name: "driver:gcloud-secret"
+          required: true
         - name: "driver:gcloud-kms"
           required: true
       operator:
@@ -315,6 +317,48 @@ drivers:
                   .. code:: go
 
                      retbytes, err := driver.RPCCallRaw("driver:gcloud-kms", "decrypt", cipherbytes)
+
+      gcloud-secret:
+        name: gcloud-secret
+        type: builtin
+        handlerData:
+          shortName: gcloud-secret
+
+        meta:
+          description:
+            - >
+              This driver enables Honeydipper to fetch items stored in Google Secret Manager.
+
+            - >
+              With access to Google Secret Manager, Honeydipper doesn't have to rely on cipher texts stored directly into the
+              configurations in the repo. Instead, it can query the Google Secret Manager, and get access to the secrets based
+              on the permissions granted to the identity it uses. :code:`DipperCL` uses a keyword interpolation to detect the items
+              that need to be looked up using :code:`LOOKUP[<driver>,<key>]`. See blow for example.
+
+            - example: |
+                mydata: LOOKUP[gcloud-secret,projects/foo/secrets/bar/versions/latest]
+
+            - >
+              As of now, the driver doesn't take any configuration other than the generic `api_timeout`. It uses the default service
+              account as its identity.
+
+          RPCs:
+            - name: lookup
+              description: Lookup a secret in Google Secret Manager
+              parameters:
+                - name: "*"
+                  description: The whole payload is used as a byte array of string for the key
+              returns:
+                - name: "*"
+                  description: The whole payload is a byte array of plaintext
+
+              notes:
+                - See below for an example usage on invoking the RPC from another driver
+                - |
+
+                  .. code:: go
+
+                     retbytes, err := driver.RPCCallRaw("driver:gcloud-secret", "lookup", []byte("projects/foo/secrets/bar/versions/latest"))
 
       gcloud-dataflow:
         name: gcloud-dataflow


### PR DESCRIPTION
Since Honeydipper version 2.3.0, a driver has been added to fetch
items from google secret manager.