### PR TITLE
feat(kubernetes): handle secrets with berglas

### DIFF
--- a/kubernetes/contexts.yaml
+++ b/kubernetes/contexts.yaml
@@ -24,23 +24,55 @@ contexts:
           shell_prefix: [ "bash", "-c" ]
         git:
           image: alpine/git:latest
-          command_prefix: []
+          command_entry: [ "git" ]
           shell_entry: [ "/bin/sh", "-c" ]
         tf:
           image: hashicorp/terraform:light
           imagePullPolicy: Always
-          command_prefix: []
+          command_entry: [ "/bin/terraform" ]
           shell_entry: [ "/bin/sh", "-c" ]
         helm:
           image: alpine/helm:latest
-          command_prefix: []
+          command_entry: [ "helm" ]
           shell_entry: [ "/bin/sh", "-c" ]
         gcloud:
           image: google/cloud-sdk:latest
-          command_prefix: []
+          command_prefix: [ "/bin/bash", "-c" ]
           shell_entry: [ "/bin/bash", "-c" ]
+        berglas:
+          image: us-docker.pkg.dev/berglas/berglas/berglas:latest
+          command_prefix: []
+          shell_entry: [ "/bin/sh", "-c" ]
 
       predefined_steps:
+        install-berglas:
+          name: install-berglas
+          type: berglas
+          shell: |
+            mkdir -p /honeydipper/.bin
+            cp /bin/berglas /honeydipper/.bin/berglas
+
+        berglas-files:
+          name: berglas-files
+          type: berglas
+          shell: |
+            {{- range .ctx.berglas_files }}
+            FILE="{{ .file }}"
+            DIR="$(dirname "$FILE")"
+            mkdir -p "$DIR"
+            berglas access "{{ .secret }}" > "$FILE"
+
+            {{- with .owner }}
+            chown "{{ . }}" "$FILE"
+            {{- end }}
+            {{- with .mode }}
+            chmod "{{ . }}" "$FILE"
+            {{- end }}
+            {{- with .dir_mode }}
+            chmod "{{ . }}" "$DIR"
+            {{- end }}
+            {{- end }}
+
         kms:
           name: kms
           type: gcloud

--- a/kubernetes/resources/honeydipper-job.yaml.tmpl
+++ b/kubernetes/resources/honeydipper-job.yaml.tmpl
@@ -31,10 +31,14 @@
         {{- $script_types := index . 2 }}
         {{- $env := index . 3 }}
         {{- $volumes := index . 4 }}
+        {{- $useBerglas := and (ne $step.type "berglas") (index . 5 | empty | not) }}
+        {{- $berglasPrefix := list "/honeydipper/.bin/berglas" "exec" "--" }}
 
         {{- with $step }}
         {{- $useShell := not (empty .shell) }}
         {{- $processor := index $script_types (default "bash" .type) }}
+        {{- $shell_entry := $useBerglas | ternary (concat $berglasPrefix (default (list) $processor.shell_entry)) $processor.shell_entry }}
+        {{- $command_entry := $useBerglas | ternary (concat $berglasPrefix (default (list) $processor.command_entry)) $processor.command_entry }}
         - name: step-{{ default $index .name }}
           image: {{ $processor.image }}
           {{- with $processor.imagePullPolicy }}
@@ -54,8 +58,8 @@
             {{ template "volumeMounts" $volumes }}
             {{ template "volumeMounts" .volumes }}
           {{- if $useShell }}
-          {{-   if $processor.shell_entry }}
-          command: {{ $processor.shell_entry | toJson }}
+          {{-   if $shell_entry }}
+          command: {{ $shell_entry | toJson }}
           {{-   end }}
           {{-   if typeIs "string" .shell }}
           args: {{ append (default (list) $processor.shell_prefix) .shell | toJson }}
@@ -69,8 +73,8 @@
             {{-   end }}
           {{-   end }}
           {{- else }}
-          {{-   if $processor.command_entry }}
-          command: {{ $processor.command_entry | toJson }}
+          {{-   if $command_entry }}
+          command: {{ $command_entry | toJson }}
           {{-   end }}
           {{-   if typeIs "string" .command }}
           args: {{ append (default (list) $processor.command_prefix) .command | toJson }}
@@ -92,7 +96,7 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  generateName: "honeydipper-job-"
+  generateName: $ctx.generateName,"honeydipper-job-"
   labels:
     creator: honeydipper
     honeydipper-unique-identifier: "{{ $uniqueID }}"
@@ -107,18 +111,18 @@ spec:
       initContainers:
         {{- range $index, $step := . }}
         {{-   if empty $step.as_sidecar }}
-        {{-     template "container" (list $step $index $.ctx.script_types $.ctx.env $.ctx.volumes) }}
+        {{-     template "container" (list $step $index $.ctx.script_types $.ctx.env $.ctx.volumes $.ctx.use_berglas) }}
         {{-   end }}
         {{- end }}
       {{- end }}
       containers:
         {{- with (last .ctx.steps) }}
-        {{-   template "container" (list . $finalStepNum $.ctx.script_types $.ctx.env $.ctx.volumes) }}
+        {{-   template "container" (list . $finalStepNum $.ctx.script_types $.ctx.env $.ctx.volumes $.ctx.use_berglas) }}
         {{- end }}
         {{- with (initial .ctx.steps) }}
         {{-   range $index, $step := . }}
         {{-     if not (empty $step.as_sidecar) }}
-        {{-       template "container" (list $step $index $.ctx.script_types $.ctx.env $.ctx.volumes) }}
+        {{-       template "container" (list $step $index $.ctx.script_types $.ctx.env $.ctx.volumes $.ctx.use_berglas) }}
         {{-     end }}
         {{-   end }}
         {{- end }}

--- a/kubernetes/workflows.yaml
+++ b/kubernetes/workflows.yaml
@@ -13,7 +13,9 @@ workflows:
         export:
           steps: |
             :yaml:---
-            {{- range .ctx.steps }}
+            {{- $steps := empty .ctx.berglas_files | ternary .ctx.steps (prepend .ctx.steps "berglas-files") }}
+            {{- $steps = empty .ctx.use_berglas | ternary $steps (prepend $steps "install-berglas") }}
+            {{- range $steps }}
             {{- if (typeIs "string" .) }}
             - {{ index $.ctx.predefined_steps . | toJson }}
             {{- else }}
@@ -114,6 +116,22 @@ workflows:
 
             Also supported are :code:`env` and :code:`volumes` for defining the environment variables and
             volumes specific to this step.
+        - name: generateName
+          description: The prefix for all jobs created by :code:`Honeydipper`, defaults to :code:`honeydipper-job-`.
+
+        - name: use_berglas
+          description: >
+            Indicates if the environment variables should be parsed by
+            :code:`Berglas` to fetch the secrets. See `Berglas website <https://github.com/GoogleCloudPlatform/berglas>`_ for
+            detail. This is done by prepend the :code:`berglas exec --` to the :code:`ENTRYPOINT` of the containers.
+
+        - name: berglas_files
+          description: >
+            Use :code:`Berglas` to fetch secret files. A list of objects, each has a :code:`file` and a :code:`secret` field.
+            Optionally, you can specify the :code:`owner`, :code:`mode` and :code:`dir_mode` for the file. This parameter can
+            be used alone without the :code:`use_berglas` flag. This is achieved by adding an :code:`initContainer` to run the
+            :code:`berglas access "$secret" > "$file"` commands.
+
         - name: env
           description: >
             A list of environment variables for all the steps.
@@ -219,6 +237,54 @@ workflows:
                       name: git_commit
                       workingDir: /honeydipper/repo
                       shell: git commit -m 'change' -a && git push
+
+        - An example with :code:`Berglas` decryption
+        - example: |
+            ---
+            workflows:
+              make_change:
+                call_workflow: run_kubernetes
+                with:
+                  use_berglas: true
+                  system: myrepo.k8s
+                  steps:
+                    - git_clone # predefined step
+                    - type: node
+                      workingDir: /honeydipper/repo
+                      shell: npm ci
+                      env:
+                        # Berglas way of accessing Google Secret Manager secrets.
+                        # assuming proper IAM permissions are granted to the service account.
+                        NPM_TOKEN: sm://my-gcp-project/my-secret-manager-secret
+
+        - Another example with :code:`Berglas` decryption for files. Pay attention to how the file ownership is mapped
+          to the :code:`runAsUser`.
+        - example: |
+            ---
+            workflows:
+              make_change:
+                call_workflow: run_kubernetes
+                with:
+                  system: myrepo.k8s
+                  steps:
+                    - use: git_clone
+                      env:
+                        - name: HOME
+                          value: /honeydipper/myuser
+                      workingDir: /honeydipper/myuser
+                      securityContext:
+                        runAsUser: 3001
+                        runAsGroup: 3001
+                        fsGroup: 3001
+                    - type: node
+                      workingDir: /honeydipper/myuser/repo
+                      shell: npm ci
+                  berglas_files:
+                    - file: /honeydipper/myuser/.ssh/id_rsa
+                      secret: sm://my-project/my-ssh-key
+                      owner: "3001:3001"
+                      mode: "600"
+                      dir_mode: "600"
 
     on_failure: exit
     steps:


### PR DESCRIPTION
[Berglas](https://github.com/GoogleCloudPlatform/berglas) is an utility
commonly used for handling secrets in kubernetes. It can be used as a
CLI too, an administration controller or a library.

We use Berglas CLI as a wrapper to our jobs that run scripts and
commands. The Berglas command will fetch the secrets from supported
backend to parse the environment variables.

To keep the existing jobs compatible, the feature is only activated when
`.ctx.use_berglas` is set to true.

Also, if `.ctx.berglas_files` is defined, there will be a step to fetch
the secrets and put them into designated files, and ensure the
ownership, mode and directory mode.