### PR TITLE
feat(kubernetes): handle secret files with berglas

### DIFF
--- a/kubernetes/contexts.yaml
+++ b/kubernetes/contexts.yaml
@@ -24,23 +24,48 @@ contexts:
           shell_prefix: [ "bash", "-c" ]
         git:
           image: alpine/git:latest
-          command_prefix: []
+          command_entry: [ "git" ]
           shell_entry: [ "/bin/sh", "-c" ]
         tf:
           image: hashicorp/terraform:light
           imagePullPolicy: Always
-          command_prefix: []
+          command_entry: [ "/bin/terraform" ]
           shell_entry: [ "/bin/sh", "-c" ]
         helm:
           image: alpine/helm:latest
-          command_prefix: []
+          command_entry: [ "helm" ]
           shell_entry: [ "/bin/sh", "-c" ]
         gcloud:
           image: google/cloud-sdk:latest
-          command_prefix: []
+          command_prefix: [ "/bin/bash", "-c" ]
           shell_entry: [ "/bin/bash", "-c" ]
+        berglas:
+          image: us-docker.pkg.dev/berglas/berglas/berglas:latest
+          command_prefix: []
+          shell_entry: [ "/bin/sh", "-c" ]
 
       predefined_steps:
+        berglas-files:
+          name: berglas-files
+          type: berglas
+          shell: |
+            {{- range .ctx.berglas_files }}
+            FILE="{{ .file }}"
+            DIR="$(dirname "$FILE")"
+            mkdir -p "$DIR"
+            berglas access "{{ .secret }}" > "$FILE"
+
+            {{- with .owner }}
+            chown "{{ . }}" "$FILE"
+            {{- end }}
+            {{- with .mode }}
+            chmod "{{ . }}" "$FILE"
+            {{- end }}
+            {{- with .dir_mode }}
+            chmod "{{ . }}" "$DIR"
+            {{- end }}
+            {{- end }}
+
         kms:
           name: kms
           type: gcloud

--- a/kubernetes/resources/honeydipper-job.yaml.tmpl
+++ b/kubernetes/resources/honeydipper-job.yaml.tmpl
@@ -92,7 +92,7 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  generateName: "honeydipper-job-"
+  generateName: $ctx.generateName,"honeydipper-job-"
   labels:
     creator: honeydipper
     honeydipper-unique-identifier: "{{ $uniqueID }}"

--- a/kubernetes/workflows.yaml
+++ b/kubernetes/workflows.yaml
@@ -13,7 +13,8 @@ workflows:
         export:
           steps: |
             :yaml:---
-            {{- range .ctx.steps }}
+            {{- $steps := empty .ctx.berglas_files | ternary .ctx.steps (prepend .ctx.steps "berglas-files") }}
+            {{- range $steps }}
             {{- if (typeIs "string" .) }}
             - {{ index $.ctx.predefined_steps . | toJson }}
             {{- else }}
@@ -114,6 +115,21 @@ workflows:
 
             Also supported are :code:`env` and :code:`volumes` for defining the environment variables and
             volumes specific to this step.
+        - name: generateName
+          description: The prefix for all jobs created by :code:`Honeydipper`, defaults to :code:`honeydipper-job-`.
+
+        - name: berglas_files
+          description: |
+            Use :code:`Berglas` to fetch secret files. A list of objects, each
+            has a :code:`file` and a :code:`secret` field.  Optionally, you can
+            specify the :code:`owner`, :code:`mode` and :code:`dir_mode` for
+            the file. This is achieved by adding an :code:`initContainer` to
+            run the :code:`berglas access "$secret" > "$file"` commands.
+
+            :code:`Berglas` is a utility for handling secrets. See their
+            `github repo <https://github.com/GoogleCloudPlatform/berglas>`_ for
+            details.
+
         - name: env
           description: >
             A list of environment variables for all the steps.
@@ -219,6 +235,35 @@ workflows:
                       name: git_commit
                       workingDir: /honeydipper/repo
                       shell: git commit -m 'change' -a && git push
+
+        - An example with :code:`Berglas` decryption for files. Pay attention to how the file ownership is mapped
+          to the :code:`runAsUser`.
+        - example: |
+            ---
+            workflows:
+              make_change:
+                call_workflow: run_kubernetes
+                with:
+                  system: myrepo.k8s
+                  steps:
+                    - use: git_clone
+                      env:
+                        - name: HOME
+                          value: /honeydipper/myuser
+                      workingDir: /honeydipper/myuser
+                      securityContext:
+                        runAsUser: 3001
+                        runAsGroup: 3001
+                        fsGroup: 3001
+                    - type: node
+                      workingDir: /honeydipper/myuser/repo
+                      shell: npm ci
+                  berglas_files:
+                    - file: /honeydipper/myuser/.ssh/id_rsa
+                      secret: sm://my-project/my-ssh-key
+                      owner: "3001:3001"
+                      mode: "600"
+                      dir_mode: "600"
 
     on_failure: exit
     steps:


### PR DESCRIPTION
[Berglas](https://github.com/GoogleCloudPlatform/berglas) is an utility
commonly used for handling secrets in kubernetes. It can be used as a
CLI tool, an administration controller or a library.

If `.ctx.berglas_files` is defined, there will be a step to fetch the
secrets and put them into designated files, and ensure the ownership,
mode and directory mode.

Also included in this PR, is the capability to name the kubernetes jobs
with customized prefixes instead of `honeydipper-job-`.

This is a portion from the original PR #107 that doesn't involve copying
the berglas binary and use it as entry point to handle secrets in
environment variables.