### PR TITLE
fix(kubernetes): generateName use go template

### DIFF
--- a/kubernetes/resources/honeydipper-job.yaml.tmpl
+++ b/kubernetes/resources/honeydipper-job.yaml.tmpl
@@ -92,7 +92,7 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  generateName: $ctx.generateName,"honeydipper-job-"
+  generateName: {{ default "honeydipper-job-" $.ctx.generateName }}
   labels:
     creator: honeydipper
     honeydipper-unique-identifier: "{{ $uniqueID }}"


### PR DESCRIPTION
The dollar interpolation won't work in the template files, so switch to
use go templating.