### PR TITLE
fix(pagerduty): appending ctx data in workflow

### DIFF
--- a/pagerduty.yaml
+++ b/pagerduty.yaml
@@ -173,14 +173,14 @@ systems:
             offset: $ctx.offset,"0"
             query: $?ctx.tag_name
         export:
-          escalation_policies+: |
+          result: |
             :yaml:---
             {{- range .data.json.escalation_policies }}
             {{- if contains (default "" $.ctx.schedule_pattern | lower) (lower .summary) }}
               - {{ . | toJson }}
             {{- end }}
             {{- end }}
-          escalation_policy_ids+: |
+          result_ids: |
             :yaml:---
             {{- range .data.json.escalation_policies }}
             {{- if contains (default "" $.ctx.schedule_pattern | lower) (lower .summary) }}
@@ -208,7 +208,7 @@ systems:
             offset: "{{ . }}"
             {{- end }}
         export:
-          oncalls+: $data.json.oncalls
+          result: $?data.json.oncalls
           offset: '{{ add (default 0 .ctx.offset) (len .data.json.oncalls) }}'
           EOL: '{{ if ne (len .data.json.oncalls) 100 }}true{{ end }}'
 
@@ -246,10 +246,14 @@ workflows:
           - $?ctx.EOL
         steps:
           - call_function: pagerduty.getEscalationPolicies
+            export:
+              escalation_policy_ids+: $ctx.result_ids
         no_export:
           - offset
           - EOL
           - escalation_policies
+          - result
+          - result_ids
       - if:
           - $?ctx.escalation_policy_ids
         steps:
@@ -257,9 +261,12 @@ workflows:
               - $?ctx.EOL
             steps:
               - call_function: pagerduty.whoisoncall
+                export:
+                  oncalls+: $ctx.result
             no_export:
               - offset
               - EOL
+              - result
     export:
       on_call_table: |
         :yaml:---


### PR DESCRIPTION
When appending ctx list data, it needs to be done in workflow export
instead of function export.