### PR TITLE
feat(datadog): add more tags to heartbeat metric

### DIFF
--- a/datadog/init.yaml
+++ b/datadog/init.yaml
@@ -116,7 +116,9 @@ systems:
         parameters:
           name: '{{ .sysData.heartbeat_metric }}'
           tags:
-            - heartbeat:{{ .ctx.heartbeat }}
+            - 'heartbeat:{{ .ctx.heartbeat }}'
+            - 'expires:{{ default "24h" .ctx.heartbeat_expires }}'
+            - 'owner:{{ .ctx.heartbeat_owner }}'
 
         description: >
           This function will send a heartbeat request to datadog.
@@ -125,6 +127,10 @@ systems:
           inputs:
             - name: heartbeat
               description: The name of the heartbeat used for tagging.
+            - name: heartbeat_expires
+              description: Tag the metric with expiring duration, used for creating monitors.
+            - name: heartbeat_owner
+              description: Tag the metric with the owner.
 
       increment:
         driver: 'feature:emitter'


### PR DESCRIPTION
With more tag, we can create the monitor in Datadog easily.