### PR TITLE
fix(pagerduty): signatureSecret should not have default value

### DIFF
--- a/pagerduty.yaml
+++ b/pagerduty.yaml
@@ -35,7 +35,6 @@ systems:
       API_KEY: _place_holder_
       path: "/pagerduty"
       signatureHeader: X-PagerDuty-Signature
-      signatureSecret: _place_holder_
 
     triggers:
       alert:


### PR DESCRIPTION
The value could be a single string or a list of strings.