### PR TITLE
feat: setting default org and org_id in systems

### DIFF
--- a/circleci.yaml
+++ b/circleci.yaml
@@ -11,10 +11,13 @@ systems:
           description: The token for making API calls to `circleci`.
         - name: url
           description: The base url of the API calls, defaults to :code:`https://circleci.com/api/v2`
+        - name: org
+          description: The default org name
 
     data:
       circle_token: _place_holder_
       url: https://circleci.com/api/v2
+      org: _place_holder_
 
     functions:
       api:
@@ -36,7 +39,7 @@ systems:
           system: circleci
           function: api
         parameters:
-          URL: '{{ .sysData.url }}/project/{{ default "gh" .ctx.vcs }}/{{ .ctx.git_repo }}/envvar'
+          URL: '{{ .sysData.url }}/project/{{ default "gh" .ctx.vcs }}/{{ coalesce .ctx.git_repo (print .sysData.org "/" .ctx.repo) }}/envvar'
           method: POST
           content:
             name: $ctx.name
@@ -50,7 +53,9 @@ systems:
             - name: vcs
               description: The VCS system integrated with this circle project, :code:`github` (default) or :code:`bitbucket`.
             - name: git_repo
-              description: The repo that the pipeline execution is for, e.g. :code:`myorg/myrepo`
+              description: The repo that the env var is for, e.g. :code:`myorg/myrepo`, takes precedent over :code:`repo`.
+            - name: repo
+              description: The repo name that the env var is for, without the org, e.g. :code:`myrepo`
             - name: name
               description: Env var name
             - name: value
@@ -61,7 +66,7 @@ systems:
           system: circleci
           function: api
         parameters:
-          URL: '{{ .sysData.url }}/project/{{ default "gh" .ctx.vcs }}/{{ .ctx.git_repo }}/pipeline'
+          URL: '{{ .sysData.url }}/project/{{ default "gh" .ctx.vcs }}/{{ coalesce .ctx.git_repo  (print .sysData.org "/" .ctx.repo) }}/pipeline'
           method: POST
           content:
             branch: $ctx.git_branch
@@ -75,7 +80,9 @@ systems:
             - name: vcs
               description: The VCS system integrated with this circle project, :code:`github` (default) or :code:`bitbucket`.
             - name: git_repo
-              description: The repo that the pipeline execution is for, e.g. :code:`myorg/myrepo`
+              description: The repo that the pipeline execution is for, e.g. :code:`myorg/myrepo`, takes precedent over :code:`repo`.
+            - name: repo
+              description: The repo name that the pipeline execution is for, without the org, e.g. :code:`myrepo`
             - name: git_branch
               description: The branch that the pipeline execution is on.
             - name: pipeline_parameters

--- a/codeclimate/systems.yaml
+++ b/codeclimate/systems.yaml
@@ -10,6 +10,10 @@ systems:
           description: The token for authenticating with CodeClimate
         - name: url
           description: The CodeClimate API URL
+        - name: org
+          description: For private repos, this is the default org name
+        - name: org_id
+          description: For private repos, this is the default org ID
 
       notes:
         - For example
@@ -29,6 +33,8 @@ systems:
     data:
       api_key: _place_holder_
       url: https://api.codeclimate.com/v1
+      org: _place_holder_
+      org_id: _place_holder_
 
     functions:
       api:
@@ -71,13 +77,13 @@ systems:
           system: codeclimate
           function: api
         parameters:
-          URL: '{{ .sysData.url }}/orgs/{{ .ctx.org_id }}/repos'
+          URL: '{{ .sysData.url }}/orgs/{{ coalesce .ctx.org_id .sysData.org_id }}/repos'
           method: POST
           content:
             data:
               type: repos
               attributes:
-                url: 'https://github.com/{{ .ctx.org }}/{{ .ctx.repo }}'
+                url: 'https://github.com/{{ coalesce .ctx.org .sysData.org }}/{{ .ctx.repo }}'
 
         description: >
           Add a private GitHub repository to Code Climate.
@@ -85,9 +91,9 @@ systems:
         meta:
           inputs:
             - name: org_id
-              description: Code Climate organization ID
+              description: Code Climate organization ID, if missing use pre-configured :code:`sysData.org_id`
             - name: org
-              description: Github organization name
+              description: Github organization name, if missing use pre-configured :code:`sysData.org`
             - name: repo
               description: Github repository name
 
@@ -96,7 +102,7 @@ systems:
           system: codeclimate
           function: api
         parameters:
-          URL: '{{ .sysData.url }}/repos?github_slug={{ .ctx.org }}/{{ .ctx.repo }}'
+          URL: '{{ .sysData.url }}/repos?github_slug={{ coalesce .ctx.org .sysData.org }}/{{ .ctx.repo }}'
           method: GET
         export:
           repo_info: $?data.json.data[0]
@@ -107,6 +113,6 @@ systems:
         meta:
           inputs:
             - name: org
-              description: Github organization name
+              description: Github organization name, if missing use pre-configured :code:`sysData.org`
             - name: repo
               description: Github repository name

--- a/codeclimate/workflows.yaml
+++ b/codeclimate/workflows.yaml
@@ -13,16 +13,6 @@ workflows:
   codeclimate/add_private_repo:
     description: Add a private Github repository to Code Climate
     with:
-      org_id: |-
-        {{- with .ctx.org_id | trim }}
-        {{- if empty . }}{{ fail "Please specify a Code Climate organization ID" }}{{ end -}}
-        {{ . }}
-        {{- end }}
-      org: |-
-        {{- with .ctx.repo | trim | trimPrefix "https://github.com/" | splitList "/" | first | trimPrefix "@" }}
-        {{- if empty . }}{{ fail "Please specify a Github organization name" }}{{ end -}}
-        {{ . }}
-        {{- end }}
       repo: |-
         {{- with .ctx.repo | trim | trimPrefix "https://github.com/" | splitList "/" | last }}
         {{- if empty . }}{{ fail "Please specify a repo name" }}{{ end -}}
@@ -39,4 +29,3 @@ workflows:
         with:
           name: CC_TEST_REPORTER_ID
           value: $ctx.repo_info.attributes.test_reporter_id
-          git_repo: "{{ .ctx.org_id }}/{{ .ctx.repo }}"


### PR DESCRIPTION
CircleCI system functions used to take only `git_repo` input variable
that represents the whole slug `org/repo`. Now, you can specify `repo`
with name only and use the system default org.

CodeClimate system functions used to take every input from `.ctx`, now
we can set the `org_id` and `org` at the system level as default value.
When they are missing in `.ctx`, system default will be used.