### PR TITLE
fix: extract repo_info from api result

### DIFF
--- a/codeclimate/systems.yaml
+++ b/codeclimate/systems.yaml
@@ -105,7 +105,10 @@ systems:
           URL: '{{ .sysData.url }}/repos?github_slug={{ coalesce .ctx.org .sysData.org }}/{{ .ctx.repo }}'
           method: GET
         export:
-          repo_info: $?data.json.data[0]
+          result_json: ':yaml:{{ .data.body }}'
+        export_on_success:
+          repo_info: $?ctx.result_json.data.0
+
 
         description: >
           Get repository information


### PR DESCRIPTION
The web driver only parse json blob when the content type is exactly
`application/json`. Some of the APIs return with
`application/vnd.api+json`, and the content is not parsed. So we have to
manually parse the content into a object using `DipperCL`, then extract
the `repo_info`.

This should be fixed in the web driver code itself. This is just a
temporary workaround, and will be removed once the fix is implemented in
driver.