### PR TITLE
feat(slack): allow specify text besides blocks in messages

### DIFF
--- a/slack/systems.yaml
+++ b/slack/systems.yaml
@@ -65,6 +65,8 @@ systems:
               {{ end }}
             response_type: '{{ default "ephemeral" .ctx.response_type }}'
             blocks: $?ctx.blocks
+            text: $?ctx.text
+            mrkdwn: :yaml:{{ default "true" .ctx.mrkdwn }}
 
       reply:
         target:


### PR DESCRIPTION
Allow specify text in the slack message besides using blocks.