### PR TITLE
fix: slack interactive message support

### DIFF
--- a/slack/rules.yaml
+++ b/slack/rules.yaml
@@ -5,11 +5,13 @@ rules:
         system: slack_bot
         trigger: interact
     do:
-      call_workflow: resume_workflow
       with:
         resume_token: $ctx.slack_payload.callback_id,ctx.slack_payload.actions.0.block_id
         labels_status: success
         resume_payload: $ctx.slack_payload
+      if:
+        - '{{ hasPrefix "/" .ctx.resume_token }}'
+      call_workflow: resume_workflow
       context: mute
 
   - when:

--- a/slack/rules.yaml
+++ b/slack/rules.yaml
@@ -7,9 +7,10 @@ rules:
     do:
       call_workflow: resume_workflow
       with:
-        resume_token: $ctx.slack_payload.callback_id
+        resume_token: $ctx.slack_payload.callback_id,ctx.slack_payload.actions.0.block_id
         labels_status: success
         resume_payload: $ctx.slack_payload
+      context: mute
 
   - when:
       source:

--- a/workflow_helper.yaml
+++ b/workflow_helper.yaml
@@ -204,11 +204,12 @@ workflows:
     call_driver: redispubsub.send
     with:
       broadcastSubject: resume_session
-      key: $ctx.resume_token
       labels:
         status: $ctx.labels_status
         reason: $?ctx.labels_reason
-      payload: $?ctx.resume_payload
+      data:
+        payload: $?ctx.resume_payload
+        key: $ctx.resume_token
 
   snooze_alert:
     description: snooze an alert


### PR DESCRIPTION
 * accepting block_id from block action messages (new block style UI)
 * muting the resume_workflow
 * injecting the resume_token in the right place in the data structure