### PR TITLE
feat(gcloud): setup gcloud credential in k8s jobs using berglas

### DIFF
--- a/gcloud/contexts.yaml
+++ b/gcloud/contexts.yaml
@@ -14,9 +14,14 @@ contexts:
         gcloud_auth:
           type: gcloud
           name: google-auth
-          shell: gcloud auth activate-service-account --key-file=/etc/gcloud/service-account.json
+          shell: gcloud auth activate-service-account --key-file=/honeydipper/.config/gcloud/secret/service-account.json
+
+        gcloud_auth_with_k8s_secret:
+          type: gcloud
+          name: google-auth
+          shell: gcloud auth activate-service-account --key-file=/honeydipper/.config/gcloud/secret/service-account.json
           volumes:
-            - mountPath: /etc/gcloud/service-account.json
+            - mountPath: /honeydipper/.config/gcloud/secret/service-account.json
               subPath: service-account.json
               volume:
                 name: gcloud-service-credentials

--- a/gcloud/workflows.yaml
+++ b/gcloud/workflows.yaml
@@ -2,19 +2,32 @@
 workflows:
   use_google_credentials:
     if:
-      - $?ctx.google_credentials_secret
+      - $?ctx.google_credentials_berglas_secret
     export:
+      berglas_files+:
+        - file: /honeydipper/.config/gcloud/secret/service-account.json
+          secret: $ctx.google_credentials_berglas_secret
+          mode: "600"
       env+:
         - gcloud_config
       steps+:
         - gcloud_auth
+    else:
+      if:
+        - $?ctx.google_credentials_secret
+      export:
+        env+:
+          - gcloud_config
+        steps+:
+          - gcloud_auth_with_k8s_secret
 
     meta:
       description:
         - >
           This workflow will add a step into :code:`steps` context variable so
-          the following :code:`run_kubernetes` workflow can use default google credentials
-          or specify a credential through a k8s secret.
+          the following :code:`run_kubernetes` workflow can use default google credentials,
+          specify a credential through a k8s secret, or use `berglas <https://github.com/GoogleCloudPlatform/berglas>`_ to fetch the credentials
+          at runtime(recommended).
 
         - highlight: >
             It is recommended to always use this with :code:`run_kubernetes` workflow if
@@ -22,7 +35,9 @@ workflows:
 
       inputs:
         - name: google_credentials_secret
-          description: The name of the k8s secret storing the service account key, if missing, use default service account
+          description: The name of the k8s secret storing the service account key
+        - name: google_credentials_berglas_secret
+          description: The name of the secret to be fetched using berglas, if no secrets is specified, use default service account
 
       notes:
         - For example
@@ -36,9 +51,32 @@ workflows:
                       google_credentials_secret: my_k8s_secret
                   - call_workflow: run_kubernetes
                     with:
+                      # notice we use append modifier here ("+") so
+                      # steps pre-configured through :code:`use_google_credentials`
+                      # wont be overwritten.
                       steps+:
                         - type: gcloud
                           shell: gcloud compute disks list
+        - An example with berglas secret
+        - example: |
+            ---
+            workflows:
+              run_my_job:
+                with:
+                  google_credentials_berglas_secret: sm://my-gcp-project/my-service-account-secret
+                steps:
+                  - call_workflow: use_google_credentials
+                  - call_workflow: run_kubernetes
+                    with:
+                      steps+:
+                        - type: gcloud
+                          shell: gcloud compute disks list
+                  - call_workflow: use_google_credentials
+                  - call_workflow: run_kubernetes
+                    with:
+                      steps+:
+                        - type: gcloud
+                          shell: gsutil ls gs://mybucket
 
   use_gcloud_kubeconfig:
     export:


### PR DESCRIPTION
Besides using k8s secret to setup gcloud credentials, using berglas to
fetch secrets at runtime is also supported.