### PR TITLE
fix: add a method for not overwriting interactive message

### DIFF
--- a/slack/systems.yaml
+++ b/slack/systems.yaml
@@ -63,19 +63,19 @@ systems:
                 color: '{{ index .ctx.chat_colors .ctx.message_type }}'
                 text: {{ .ctx.message | toJson }}
               {{ end }}
-            response_type: '{{ default "ephemeral" .ctx.response_type }}'
             blocks: $?ctx.blocks
             text: $?ctx.text
             mrkdwn: :yaml:{{ default "true" .ctx.mrkdwn }}
 
-      update_response:
+      add_response:
         target:
           system: slack
           function: send_message
         parameters:
           URL: $ctx.response_url
           content:
-            replace_original: true
+            replace_original: false
+            response_type: '{{ default "ephemeral" .ctx.response_type }}'
 
       reply:
         target:
@@ -83,6 +83,9 @@ systems:
           function: send_message
         parameters:
           URL: $ctx.response_url
+          content:
+            replace_original: true
+            response_type: '{{ default "ephemeral" .ctx.response_type }}'
 
         description: >
           This function send a reply message to a slash command request. It is recommended to use
@@ -350,7 +353,7 @@ systems:
           header:
             Authorization: 'Bearer {{ .sysData.token }}'
 
-      update_response:
+      add_response:
         parameters:
           header:
             Authorization: 'Bearer {{ .sysData.token }}'

--- a/workflow_helper.yaml
+++ b/workflow_helper.yaml
@@ -64,8 +64,8 @@ workflows:
         cases:
           "reply":
             call_function: '{{ .ctx.chat_system }}.reply'
-          "update_response":
-            call_function: '{{ .ctx.chat_system }}.update_response'
+          "add_response":
+            call_function: '{{ .ctx.chat_system }}.add_response'
         default:
           call_function: '{{ .ctx.chat_system }}.{{ empty .ctx.update |ternary "say" "update_message" }}'
     no_export:


### PR DESCRIPTION
When replying to a slack interactive payload, slack will, by default, overwrite the existing message. We need a method to send a new message without overwriting the existing one.