### PR TITLE
fix: support kubernetes job env value types

### DIFF
--- a/kubernetes/resources/honeydipper-job.yaml.tmpl
+++ b/kubernetes/resources/honeydipper-job.yaml.tmpl
@@ -13,10 +13,10 @@
 {{- define "expandEnvironments" }}
             {{- if kindIs "map" . }}
             {{- range $k, $v := . }}
-            {{- if typeIs "string" $v }}
-            - {{ dict "name" $k "value" $v | toJson }}
-            {{- else }}
+            {{- if kindIs "map" $v }}
             - {{ set (deepCopy $v) "name" $k | toJson }}
+            {{- else }}
+            - {{ dict "name" $k "value" $v | toJson }}
             {{- end }}
             {{- end }}
             {{- else }}


### PR DESCRIPTION
Right now, the env value only supports string and map. We need to be able to support numbers, boolean as well.