### PR TITLE
fix: extend k8s job timeout to allow log fetching

### DIFF
--- a/kubernetes/resources/honeydipper-job.yaml.tmpl
+++ b/kubernetes/resources/honeydipper-job.yaml.tmpl
@@ -159,7 +159,7 @@ spec:
   backoffLimit: {{ default 0 .ctx.k8s_job_backoffLimit }}
   parallelism: {{ default 1 .ctx.parallelism }}
   {{- with .ctx.timeout }}
-  activeDeadlineSeconds: {{ . }}
+  activeDeadlineSeconds: {{ . | int | add 60 }}
   {{- end }}
   {{- with .ctx.cleanupAfter }}
   TTLSecondsAfterFinished: {{ . }}


### PR DESCRIPTION
If the k8s job and the Honeydipper operator uses the same timeout, it creates a race condition for the operator to fetch logs. Extend the job timeout a little longer so the logs can fetched.