### PR TITLE
fix: support predefine_ var and vol in steps

### DIFF
--- a/gcloud/gke.yaml
+++ b/gcloud/gke.yaml
@@ -6,8 +6,11 @@ systems:
         gcloud-gke:
           joblinks:
             k8s_job:
-              url: "https://console.cloud.google.com/kubernetes/job/{{ .params.source.location }}/{{ .params.source.cluster }}/default/{{ .data.metadata.name }}?project={{ .params.source.project }}&tab=details&duration=PT1H&pod_summary_list_tablesize=20&service_list_datatablesize=20"
+              url: "https://console.cloud.google.com/kubernetes/job/{{ .params.source.location }}/{{ .params.source.cluster }}/{{ default `default` .params.namespace }}/{{ .data.metadata.name }}/details?project={{ .params.source.project }}"
               text: See Kubernetes job {{ .data.metadata.name }} in console
             log:
-              url: "https://console.cloud.google.com/logs/query?project={{ .params.source.project }}&query=resource.type%3D%22k8s_container%22%0Aresource.labels.project_id%3D%22{{ .params.source.project }}%22%0Aresource.labels.location%3D%22{{ .params.source.location }}%22%0Aresource.labels.cluster_name%3D%22{{ .params.source.cluster }}%22%0Aresource.labels.namespace_name%3D%22{{ default `default` .params.namespace }}%22%0Alabels.%22k8s-pod%2Fjob-name%22%3D%22{{ .data.metadata.name }}%22"
+              url: "https://console.cloud.google.com/logs/query?\
+                project={{ .params.source.project }}&\
+                query=resource.type%3D%22k8s_container%22%0Aresource.labels.project_id%3D%22{{ .params.source.project }}%22%0Aresource.labels.location%3D%22{{ .params.source.location }}%22%0Aresource.labels.cluster_name%3D%22{{ .params.source.cluster }}%22%0Aresource.labels.namespace_name%3D%22{{ default `default` .params.namespace }}%22%0Alabels.%22k8s-pod%2Fjob-name%22%3D%22{{ .data.metadata.name }}%22&\
+                cursorTimestamp={{ dateInZone `2006-01-02T15:04:05.999999999Z` (now) `UTC` }}"
               text: View Kubernetes job logs in Stackdriver

--- a/kubernetes/workflows.yaml
+++ b/kubernetes/workflows.yaml
@@ -32,43 +32,99 @@ workflows:
     steps:
       - description: interpolating predefined variables
         export:
-          steps: |
-            :yaml:---
-            {{- range .ctx.steps }}
-            {{- if (typeIs "string" .) }}
-            - {{ index $.ctx.predefined_steps . | toJson }}
-            {{- else }}
-            {{- if not (empty .use) }}
-            - {{ index $.ctx.predefined_steps .use | merge (omit . "use") | toJson }}
-            {{- else }}
-            - {{ toJson . }}
-            {{- end }}
-            {{- end }}
-            {{- else }}
-            []
-            {{- end }}
-          env: |
-            :yaml:---
-            {{- range .ctx.env }}
-            {{- if (typeIs "string" .) }}
-            - {{ index $.ctx.predefined_env . | toJson }}
-            {{- else }}
-            - {{ toJson . }}
-            {{- end }}
-            {{- else }}
-            []
-            {{- end }}
-          volumes: |
-            :yaml:---
-            {{- range .ctx.volumes }}
-            {{- if (typeIs "string" .) }}
-            - {{ index $.ctx.predefined_volumes . | toJson }}
-            {{- else }}
-            - {{ toJson . }}
-            {{- end }}
-            {{- else }}
-            []
-            {{- end }}
+          steps: |-
+            {{ $newSteps := list }}
+            {{ range $_, $currentStep := .ctx.steps }}
+            {{   if (typeIs "string" $currentStep) }}
+            {{     $currentStep = index $.ctx.predefined_steps $currentStep }}
+            {{   end }}
+
+            {{   with $currentStep.use }}
+            {{     $currentStep = merge (omit $currentStep "use") (index $.ctx.predefined_steps .) }}
+            {{   end }}
+
+            {{   with $currentStep.env }}
+            {{     $newEnv := list }}
+            {{     range $key, $currentEnv := . }}
+            {{       if not (typeIs "string" $key) }}
+            {{         if (typeIs "string" $currentEnv) }}
+            {{           $key = $currentEnv }}
+            {{           $currentEnv = index $.ctx.predefined_env $key }}
+            {{         end }}
+            {{       end }}
+            {{       with $currentEnv }}
+            {{         if (typeIs "string" .) }}
+            {{           $currentEnv = dict "name" $key "value" . }}
+            {{         else if (len . | eq 1) }}
+            {{           $currentEnv = dict "name" (keys .| first) "value" (values .| first) }}
+            {{         else }}
+            {{           $_ := set $currentEnv "name" (dig "name" $key .) }}
+            {{         end }}
+            {{         $newEnv = append $newEnv $currentEnv }}
+            {{       end }}
+            {{     end }}
+            {{     $_ := set $currentStep "env" $newEnv }}
+            {{   end }}
+
+            {{   with $currentStep.volumes }}
+            {{     $newVolumes := list }}
+            {{     range $key, $currentVol := . }}
+            {{       if not (typeIs "string" $key) }}
+            {{         if (typeIs "string" $currentVol) }}
+            {{           $key = $currentVol }}
+            {{           $currentVol = index $.ctx.predefined_volumes $key }}
+            {{         end }}
+            {{       end }}
+            {{       with $currentVol }}
+            {{         $_ := set $currentVol.volume "name" (dig "name" $key .volume) }}
+            {{         $newVolumes = append $newVolumes $currentVol }}
+            {{       end }}
+            {{     end }}
+            {{     $_ := set $currentStep "volumes" $newVolumes }}
+            {{   end }}
+
+            {{   $newSteps = append $newSteps $currentStep }}
+            {{ end }}
+            {{ return $newSteps }}
+
+          env: |-
+            {{ $newEnv := list }}
+            {{ range $key, $currentEnv := .ctx.env }}
+            {{   if not (typeIs "string" $key) }}
+            {{     if (typeIs "string" $currentEnv) }}
+            {{       $key = $currentEnv }}
+            {{       $currentEnv = index $.ctx.predefined_env $key }}
+            {{     end }}
+            {{   end }}
+            {{   with $currentEnv }}
+            {{     if (typeIs "string" .) }}
+            {{       $currentEnv = dict "name" $key "value" . }}
+            {{     else if (len . | eq 1) }}
+            {{       $currentEnv = dict "name" (keys .| first) "value" (values .| first) }}
+            {{     else }}
+            {{       $_ := set $currentEnv "name" (dig "name" $key .) }}
+            {{     end }}
+            {{     $newEnv = append $newEnv $currentEnv }}
+            {{   end }}
+            {{ end }}
+            {{ return $newEnv }}
+
+          volumes: |-
+            {{ $newVolumes := list }}
+            {{ range $key, $currentVol := .ctx.volumes }}
+            {{   if not (typeIs "string" $key) }}
+            {{     if (typeIs "string" $currentVol) }}
+            {{       $key = $currentVol }}
+            {{       $currentVol = index $.ctx.predefined_volumes $key }}
+            {{     end }}
+            {{   end }}
+            {{   with $currentVol }}
+            {{     $_ := set $currentVol.volume "name" (dig "name" $key .volume) }}
+            {{     $newVolumes = append $newVolumes $currentVol }}
+            {{   end }}
+            {{ end }}
+            {{ return $newVolumes }}
+
       - call_workflow: inject_misc_steps
       - description: build job manifest file
         export:

--- a/slack/systems.yaml
+++ b/slack/systems.yaml
@@ -67,7 +67,7 @@ systems:
             text: $?ctx.text
             mrkdwn: :yaml:{{ default "true" .ctx.mrkdwn }}
         export:
-          slack_success: '{{ with .data.json }}{{ with .error }}{{ fail . }}{{ end }}{{ end }}'
+          slack_success: '{{ with .data.json }}{{ with .error }}{{ $.data.json | toJson | fail }}{{ end }}{{ end }}'
 
       add_response:
         target:


### PR DESCRIPTION
The predefined environment variables and volumes are not supported in
step definitions, only supported in global env and volumes. This should
add the support in the step definitions.

Also with some GKE log and job url improvements
* add cursor time to k8s log url
* correct namespace for job url