### PR TITLE
fix: allow different types of environment variable

### DIFF
--- a/kubernetes/workflows.yaml
+++ b/kubernetes/workflows.yaml
@@ -53,7 +53,7 @@ workflows:
             {{         end }}
             {{       end }}
             {{       with $currentEnv }}
-            {{         if (typeIs "string" .) }}
+            {{         if not (kindIs "map" .) }}
             {{           $currentEnv = dict "name" $key "value" . }}
             {{         else if (len . | eq 1) }}
             {{           $currentEnv = dict "name" (keys .| first) "value" (values .| first) }}
@@ -97,7 +97,7 @@ workflows:
             {{     end }}
             {{   end }}
             {{   with $currentEnv }}
-            {{     if (typeIs "string" .) }}
+            {{     if not (kindIs "map" .) }}
             {{       $currentEnv = dict "name" $key "value" . }}
             {{     else if (len . | eq 1) }}
             {{       $currentEnv = dict "name" (keys .| first) "value" (values .| first) }}


### PR DESCRIPTION
Should not assume the variable types are string, instead anything not a map should be treated the same way.