### PR TITLE
fix: send charset=utf-8 with all Content-Type headers

### DIFF
--- a/codeclimate/systems.yaml
+++ b/codeclimate/systems.yaml
@@ -45,7 +45,7 @@ systems:
           header:
             Authorization: 'Token token={{ .sysData.api_key }}'
             Accept: application/json
-            Content-Type: application/json
+            Content-Type: application/json; charset=utf-8
 
         description: >
           This is a generic function to make a circleci API call with the configured token. This

--- a/jira.yaml
+++ b/jira.yaml
@@ -55,7 +55,7 @@ systems:
           header:
             Authorization: Basic {{ .sysData.jira_credentials }}
             Accept: application/json
-            Content-Type: application/json
+            Content-Type: application/json; charset=utf-8
           content:
             fields: $ctx.ticket
         export_on_success:
@@ -121,7 +121,7 @@ systems:
           header:
             Authorization: Basic {{ .sysData.jira_credentials }}
             Accept: application/json
-            Content-Type: application/json
+            Content-Type: application/json; charset=utf-8
           content:
             body: $ctx.comment_body
 

--- a/opsgenie.yaml
+++ b/opsgenie.yaml
@@ -45,7 +45,7 @@ systems:
         parameters:
           URL: https://api.opsgenie.com/v2/alerts/{{ .ctx.alert_Id }}/snooze?identifierType=tiny
           header:
-            Content-Type: application/json
+            Content-Type: application/json; charset=utf-8
             Authorization: GenieKey {{ .sysData.API_KEY }}
           method: POST
           content:

--- a/pagerduty.yaml
+++ b/pagerduty.yaml
@@ -113,7 +113,7 @@ systems:
         parameters:
           header:
             Accept: application/vnd.pagerduty+json;version=2
-            Content-Type: application/json
+            Content-Type: application/json; charset=utf-8
             Authorization: Token token={{ .sysData.API_KEY }}
           retry: 2
 

--- a/slack/systems.yaml
+++ b/slack/systems.yaml
@@ -51,7 +51,7 @@ systems:
         rawAction: request
         parameters:
           header:
-            Content-Type: application/json
+            Content-Type: application/json; charset=utf-8
           method: POST
           content:
             attachments: |-
@@ -377,7 +377,7 @@ systems:
           URL: https://slack.com/api/users.list
           header:
             Authorization: 'Bearer {{ .sysData.token }}'
-            Content-Type: application/x-www-form-urlencoded
+            Content-Type: application/x-www-form-urlencoded; charset=utf-8
             Accept: application/json
           method: GET
           form:

--- a/web.yaml
+++ b/web.yaml
@@ -58,6 +58,6 @@ drivers:
                             parameters:
                               URL: $sysData.url
                               header:
-                                content-type: application.json; charset=utf-8
+                                content-type: application/json; charset=utf-8
                                 Authorization: Bearer {{ .sysData.token }}
 

--- a/web.yaml
+++ b/web.yaml
@@ -58,6 +58,6 @@ drivers:
                             parameters:
                               URL: $sysData.url
                               header:
-                                content-type: application.json
+                                content-type: application.json; charset=utf-8
                                 Authorization: Bearer {{ .sysData.token }}
 

--- a/webhook.yaml
+++ b/webhook.yaml
@@ -49,7 +49,7 @@ drivers:
                             url: /foo/bar
                             method: POST
                             headers:
-                              content-type: application/x-www-form-urlencoded
+                              content-type: application/x-www-form-urlencoded; charset=UTF-8
                             form:
                               s: hello
                         do:

--- a/webhook.yaml
+++ b/webhook.yaml
@@ -49,7 +49,7 @@ drivers:
                             url: /foo/bar
                             method: POST
                             headers:
-                              content-type: application/x-www-form-urlencoded; charset=UTF-8
+                              content-type: application/x-www-form-urlencoded; charset=utf-8
                             form:
                               s: hello
                         do:


### PR DESCRIPTION
**Description:**
- send charset=utf-8 with all Content-Type headers
- Slack got unhappy

<img width="468" alt="image" src="https://github.com/honeydipper/honeydipper-config-essentials/assets/3267774/a3e64178-7970-4584-8eba-98954ad82d1c">
