### PR TITLE
fix: update_message also can set ts

### DIFF
--- a/slack/systems.yaml
+++ b/slack/systems.yaml
@@ -143,6 +143,17 @@ systems:
           content:
             channel: $ctx.channel_id
             ts: $?ctx.ts.{{ .ctx.channel_id }}
+        export:
+          ts: |
+            {{ with dig "ts" .ctx.channel_id .ctx }}
+            {{   return .nil }}
+            {{ else }}
+            {{   with .data.json.ts }}
+            {{     dict $.ctx.channel_id . | return }}
+            {{   else }}
+            {{     return .nil }}
+            {{   end }}
+            {{ end }}
 
       say:
         target:


### PR DESCRIPTION
In case there is no initial message, an update message can set the ts so it can be updated in the future.