### PR TITLE
fix: pin berglas to 1.0.3

### DIFF
--- a/kubernetes/contexts.yaml
+++ b/kubernetes/contexts.yaml
@@ -70,7 +70,7 @@ contexts:
           command_prefix: []
           shell_entry: [ "/bin/bash", "-c" ]
         berglas:
-          image: us-docker.pkg.dev/berglas/berglas/berglas:latest
+          image: us-docker.pkg.dev/berglas/berglas/berglas:1.0.3
           command_prefix: []
           shell_entry: [ "/bin/sh", "-c" ]
 


### PR DESCRIPTION
berglas 2.0.0 seems broken related to logging level handling.