### PR TITLE
fix: k8s job failed pod missing

### DIFF
--- a/kubernetes/resources/honeydipper-job.yaml.tmpl
+++ b/kubernetes/resources/honeydipper-job.yaml.tmpl
@@ -165,7 +165,7 @@ spec:
       {{- with .ctx.pod_securityContext }}
       securityContext: {{ . | toJson }}
       {{- end }}
-  backoffLimit: {{ default 0 .ctx.k8s_job_backoffLimit }}
+  backoffLimit: {{ default 1 .ctx.k8s_job_backoffLimit }}
   parallelism: {{ default 1 .ctx.parallelism }}
   {{- with .ctx.timeout }}
   activeDeadlineSeconds: {{ . }}


### PR DESCRIPTION
`backoffLimit` set to 0 will result in the failed pod getting deleted. We would like to keep it for troubleshoot.