### PR TITLE
fix: circleci api put context id vs slug

### DIFF
--- a/circleci.yaml
+++ b/circleci.yaml
@@ -163,7 +163,7 @@ systems:
           content:
             name: $ctx.circleci_context_name
             owner:
-              id: '{{ default "gh" .sysData.vcs }}/{{ .sysData.org }}'
+              slug: '{{ default "gh" .sysData.vcs }}/{{ .sysData.org }}'
               type: '$sysData.owner-type,"organization"'
         export:
           circleci_context: $data.json


### PR DESCRIPTION
The create context API accepts both id or slug, but the property name must be matching. The api document has a hidden tab that show the example of using the alternatives, but easy to miss.