### PR TITLE
feat: support extra_labels in k8s job template

### DIFF
--- a/kubernetes/resources/honeydipper-job.yaml.tmpl
+++ b/kubernetes/resources/honeydipper-job.yaml.tmpl
@@ -106,12 +106,18 @@ metadata:
   labels:
     creator: {{ default "honeydipper" $.ctx.job_creator }}
     honeydipper-unique-identifier: "{{ $uniqueID }}"
+    {{- range $k, $v := (default dict $.ctx.extra_labels) }}
+    {{ $k }}: "{{ $v }}"
+    {{- end }}
 spec:
   template:
     metadata:
       labels:
         creator: {{ default "honeydipper" $.ctx.job_creator }}
         honeydipper-unique-identifier: "{{ $uniqueID }}"
+        {{- range $k, $v := (default dict $.ctx.extra_labels) }}
+        {{ $k }}: "{{ $v }}"
+        {{- end }}
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict: "false"
     spec:


### PR DESCRIPTION
**Changes Included**
- Add `extra_labels` range iteration to job metadata and pod template labels
- Guarded with `default dict` for full backwards compatibility (no labels emitted when extra_labels is not set)

**Related PRs:**
- honeydipper-cd labels: https://github.com/honeyscience/honeydipper-cd/pull/3577
- sre-tools CLI: https://github.com/PayPal-Honey/sre-tools/pull/746