### PR TITLE
feat: include Cloud Build logs in Stackdriver log link

### DIFF
--- a/gcloud/gke.yaml
+++ b/gcloud/gke.yaml
@@ -10,7 +10,7 @@ systems:
               text: See Kubernetes job {{ .data.metadata.name }} in console
             log:
               url: "https://console.cloud.google.com/logs/query;\
-                query=resource.type%3D\"k8s_container\"%0Aresource.labels.project_id%3D\"{{ .params.source.project }}\"%0Aresource.labels.location%3D\"{{ .params.source.location }}\"%0Aresource.labels.cluster_name%3D\"{{ .params.source.cluster }}\"%0Aresource.labels.namespace_name%3D\"{{ default `default` .params.namespace }}\"%0Alabels.\"k8s-pod%2Fjob-name\"%3D\"{{ .data.metadata.name }}\";\
+                query=%28resource.type%3D\"k8s_container\"%0Aresource.labels.project_id%3D\"{{ .params.source.project }}\"%0Aresource.labels.location%3D\"{{ .params.source.location }}\"%0Aresource.labels.cluster_name%3D\"{{ .params.source.cluster }}\"%0Aresource.labels.namespace_name%3D\"{{ default `default` .params.namespace }}\"%0Alabels.\"k8s-pod%2Fjob-name\"%3D\"{{ .data.metadata.name }}\"%29%0AOR%0A%28resource.type%3D\"build\"%0Aresource.labels.project_id%3D\"{{ .params.source.project }}\"%29;\
                 startTime={{ $ts := (dateInZone `2006-01-02T15:04:05.999999999Z` (now) `UTC`) }}{{ $ts }}?\
                 project={{ .params.source.project }}"
-              text: View Kubernetes job logs in Stackdriver
+              text: View Kubernetes and Cloud Build logs


### PR DESCRIPTION
**Changes Included**
- Add OR clause to the Stackdriver log URL in `gcloud/gke.yaml` to include `resource.type="build"` alongside the existing `k8s_container` filter
- Scoped by same project + `startTime` to limit noise from unrelated Cloud Builds
- Updates button text to "View Kubernetes and Cloud Build logs"

**Related PR:** https://github.com/honeyscience/honeydipper-cd/pull/3605